### PR TITLE
IMessageSession replacing IBus in v6

### DIFF
--- a/MigrateIBus/NsbHostUsingV5Core/Bootstrapper.cs
+++ b/MigrateIBus/NsbHostUsingV5Core/Bootstrapper.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NServiceBus;
 
 namespace NsbHostUsingV5Core

--- a/MigrateIBus/NsbHostUsingV5Core/Properties/AssemblyInfo.cs
+++ b/MigrateIBus/NsbHostUsingV5Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/MigrateIBus/NsbHostUsingV6Core/Boostrapper.cs
+++ b/MigrateIBus/NsbHostUsingV6Core/Boostrapper.cs
@@ -1,17 +1,26 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NServiceBus;
 
 namespace NsbHostUsingV6Core
 {
-    public class Boostrapper : IWantToRunWhenEndpointStartsAndStops
+    using Ninject;
+
+    public class Bootstrapper : IWantToRunWhenEndpointStartsAndStops
     {
         public Task Start(IMessageSession session)
         {
+            RegisterMessageSession(session);
+
+            var component = EndpointConfig.Kernel.Get<ISomeComponent>();
+            component.DoSomeDomainBehavior();
+
             return Task.FromResult(0);
+        }
+
+        private static void RegisterMessageSession(IMessageSession session)
+        {
+            EndpointConfig.Kernel.Bind<IMessageSession>().ToConstant(session);
+            EndpointConfig.Kernel.Bind<ISomeComponent>().ToConstant(new SomeComponentThatUsesTheBus());
         }
 
         public Task Stop(IMessageSession session)

--- a/MigrateIBus/NsbHostUsingV6Core/EndpointConfig.cs
+++ b/MigrateIBus/NsbHostUsingV6Core/EndpointConfig.cs
@@ -1,10 +1,12 @@
-
 namespace NsbHostUsingV6Core
 {
+    using Ninject;
     using NServiceBus;
 
     public class EndpointConfig : IConfigureThisEndpoint
     {
+        internal static StandardKernel Kernel = new StandardKernel();
+        
         public void Customize(EndpointConfiguration endpointConfiguration)
         {
             //TODO: NServiceBus provides multiple durable storage options, including SQL Server, RavenDB, and Azure Storage Persistence.
@@ -19,6 +21,7 @@ namespace NsbHostUsingV6Core
             // that you start with a shared audit queue for all your endpoints for easy integration with ServiceControl.
             endpointConfiguration.AuditProcessedMessagesTo("audit");
 
+            endpointConfiguration.UseContainer<NinjectBuilder>(c => c.ExistingKernel(Kernel));
         }
     }
 }

--- a/MigrateIBus/NsbHostUsingV6Core/NsbHostUsingV6Core.csproj
+++ b/MigrateIBus/NsbHostUsingV6Core/NsbHostUsingV6Core.csproj
@@ -30,12 +30,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Ninject.Extensions.ContextPreservation, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.Extensions.ContextPreservation.3.2.0.0\lib\net45-full\Ninject.Extensions.ContextPreservation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Ninject.Extensions.NamedScope, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.Extensions.NamedScope.3.2.0.0\lib\net45-full\Ninject.Extensions.NamedScope.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.0.0-beta0002\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Host, Version=7.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.Host.7.0.0-beta0002\lib\net452\NServiceBus.Host.exe</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NServiceBus.ObjectBuilder.Ninject, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NServiceBus.Ninject.6.0.0-beta0001\lib\net452\NServiceBus.ObjectBuilder.Ninject.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -54,6 +70,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SharedCommonUsingV6Core\SharedCommonUsingV6Core.csproj">
+      <Project>{ee92083f-be2e-493c-a2d5-e5fc22002bb8}</Project>
+      <Name>SharedCommonUsingV6Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/MigrateIBus/NsbHostUsingV6Core/Properties/AssemblyInfo.cs
+++ b/MigrateIBus/NsbHostUsingV6Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/MigrateIBus/NsbHostUsingV6Core/packages.config
+++ b/MigrateIBus/NsbHostUsingV6Core/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Ninject" version="3.2.2.0" targetFramework="net452" />
+  <package id="Ninject.Extensions.ContextPreservation" version="3.2.0.0" targetFramework="net452" />
+  <package id="Ninject.Extensions.NamedScope" version="3.2.0.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
   <package id="NServiceBus.Host" version="7.0.0-beta0002" targetFramework="net452" />
+  <package id="NServiceBus.Ninject" version="6.0.0-beta0001" targetFramework="net452" />
 </packages>

--- a/MigrateIBus/SharedCommonUsingV5Core/Properties/AssemblyInfo.cs
+++ b/MigrateIBus/SharedCommonUsingV5Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/MigrateIBus/SharedCommonUsingV6Core/Properties/AssemblyInfo.cs
+++ b/MigrateIBus/SharedCommonUsingV6Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/MigrateIBus/SharedCommonUsingV6Core/SharedCommonUsingV6Core.csproj
+++ b/MigrateIBus/SharedCommonUsingV6Core/SharedCommonUsingV6Core.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
       <HintPath>..\packages\NServiceBus.6.0.0-beta0002\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>

--- a/MigrateIBus/SharedCommonUsingV6Core/SomeComponentThatUsesTheBus.cs
+++ b/MigrateIBus/SharedCommonUsingV6Core/SomeComponentThatUsesTheBus.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Ninject;
 using NServiceBus;
 
 public class SomeComponentThatUsesTheBus : ISomeComponent
 {
-    //TODO: Ok, Remove IBus, but what gets injected here? IManageSession? IEndpointInstance? Something else?
-    public IBus Bus { get; set; }
+    [Inject]
+    public IMessageSession Bus { get; set; }
 
     public void DoSomeDomainBehavior()
     {

--- a/MigrateIBus/SharedCommonUsingV6Core/packages.config
+++ b/MigrateIBus/SharedCommonUsingV6Core/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Ninject" version="3.2.2.0" targetFramework="net452" />
   <package id="NServiceBus" version="6.0.0-beta0002" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
1. Ninject Kernel is created in `IConfigureThisEndpoint` and registered
2. Kernel is injected with `IMessageSession` in `IWantToRunWhenEndpointStartsAndStops`
3. Custom components rely on `IMessageSession`
